### PR TITLE
Disable -mbmi -mlzcnt flags

### DIFF
--- a/src/discover/discover.ml
+++ b/src/discover/discover.ml
@@ -9,7 +9,7 @@ int main(int argc, char ** argv)
 |}
 ;;
 
-let prog_lzcnt =
+let _prog_lzcnt =
   {|
 int main(int argc, char ** argv)
 {
@@ -18,7 +18,7 @@ int main(int argc, char ** argv)
 |}
 ;;
 
-let prog_tzcnt =
+let _prog_tzcnt =
   {|
 int main(int argc, char ** argv)
 {
@@ -102,8 +102,8 @@ let () =
               | true -> Some flag
               | false -> None)
            [ "-mpopcnt", prog_popcnt
-           ; "-mlzcnt", prog_lzcnt
-           ; "-mbmi", prog_tzcnt
+      (*     ; "-mlzcnt", prog_lzcnt
+           ; "-mbmi", prog_tzcnt *)
            ; "-mcrc32", prog_crc32
            ; "-mcrc32", prog_crc32_on_32bit_target
            ; "-msse4.2", prog_sse42

--- a/src/int_stubs.c
+++ b/src/int_stubs.c
@@ -115,6 +115,8 @@ intnat naive_int32_popcnt (uint32_t x)
 #define int64_ctz naive_int64_ctz
 #define int32_popcnt naive_int32_popcnt
 #define int64_popcnt naive_int64_popcnt
+#elseif /* _MSC_VER */
+#error "Not __GNUC__ Not _MSC_VER"
 #endif /* _MSC_VER */
 #endif /* defined(__GNUC__) */
 


### PR DESCRIPTION
As reported in #4, `ocaml_intrinsics` tests (that are not run in the CI) fail with an illegal instruction signal or produce incorrect results on github ci and some old macs (e.g. macbook air from 2012, with Intel Core i5-3317U CPU), because "discover" incorrectly passes `-mbmi` and `-mlzcnt` to the C compiler even though hardware target doesn't support them, and the C compiler emits BEXTR (which sigills) and LZCNT instructions (which is interpreted as BSR) in `int_stubs.c`.

This PR disables the flag for now, so that we can re-enable this library on mac_os. This generates correct code that might not be the best on newer CPUs. A proper fix (such as to check cpuid) will be implemented as a separate PR.

This PR also adds a compile-time error for unsupported configurations.