### PR TITLE
Fix aarch64 CRC32 intrinsics configure test program

### DIFF
--- a/src/discover/discover.ml
+++ b/src/discover/discover.ml
@@ -12,8 +12,8 @@ let prog_aarch64 =
 int main() {
     int64_t i64, d64;
     int32_t i32, d32;
-    __crc32ud(i64, d64);
-    __crc32uw(i32, d32);
+    __crc32cd(i64, d64);
+    __crc32cw(i32, d32);
     return 0;
 }|}
 ;;


### PR DESCRIPTION
The test program was checking for the nonexistent __crc32ud and __crc32uw instead of __crc32cd __crc32cw (as used in src/crc_stubs.c). The former ones are neither listed in ARM CRC32 standard (https://documentation-service.arm.com/static/6193910683e60c5c768e2789?token=) nor understood by GCC.